### PR TITLE
Revert to older Python version to fix deployment

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -5,7 +5,7 @@
 name: Build, test, and deploy a Python app to Azure Web App
 env:
   AZURE_WEBAPP_NAME: "webApp-emsdegnzr5u4q" # <<< Azure Web App name
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.11"
 
 on:
   push:


### PR DESCRIPTION
I pulled your changes to the GitHub action versions earlier today and my app wasn't able to successfully deploy. After some troubleshooting, I found that the problem had something to do with Python versions.

If I tried using Python 3.12 in the GitHub actions AND on Azure, I got an error in the logs for Azure about missing `libpython3.11.so`.

I'm not sure why exactly this was an issue, but since the app doesn't depend on any Python 3.12 features, I figure just using 3.11 can't hurt.